### PR TITLE
DigestResolver getData method fix

### DIFF
--- a/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
@@ -405,7 +405,7 @@ public abstract class AbstractReadExecutor
         // return immediately, or begin a read repair
         if (digestResolver.responsesMatch())
         {
-            setResult(digestResolver.getData());
+            setResult(digestResolver.getReadResponse());
         }
         else
         {
@@ -449,7 +449,7 @@ public abstract class AbstractReadExecutor
             // when the key we're trying to fetch doesn't
             // even exist, use the default data result from
             // digestResolver, which will be empty in this case
-            setResult(digestResolver.getData());
+            setResult(digestResolver.getReadResponse());
         }
     }
 

--- a/src/java/org/apache/cassandra/service/reads/DigestResolver.java
+++ b/src/java/org/apache/cassandra/service/reads/DigestResolver.java
@@ -52,11 +52,19 @@ public class DigestResolver extends ResponseResolver
             dataResponse = message.payload;
     }
 
-    public ReadResponse getData()
+    // this is the original method, NoopReadRepair has a call to this method
+    // simply change the method signature to ReadResponse getData() will raise an compiler error
+    public PartitionIterator getData()
+    {
+        assert isDataPresent();
+        return UnfilteredPartitionIterators.filter(dataResponse.makeIterator(command), command.nowInSec());
+    }
+
+    // this is a new method for AbstractReadExecutor, which may want to use ReadResponse more than once
+    public ReadResponse getReadResponse()
     {
         assert isDataPresent();
         return dataResponse;
-//        return UnfilteredPartitionIterators.filter(dataResponse.makeIterator(command), command.nowInSec());
     }
 
     public boolean responsesMatch()


### PR DESCRIPTION
Hi, this is Haochen. I get a compile time error in playing around with the ABD branch. See my comments in: [https://github.com/ZezhiWang/cassandra/commit/2b91f55351915f17b69cba9460a6b531456127e6](url)

Here is my fix, basically I restored the method signature and replaced all occurances of `digestResolver.getData()` in the last version with `digestResolver.getReadResponse()`, a method does the exact same thing.

Best wishes,
Haochen